### PR TITLE
add randperm

### DIFF
--- a/camb/functions/randperm.cpp
+++ b/camb/functions/randperm.cpp
@@ -1,0 +1,25 @@
+#include <diopi/functions.h>
+
+#include <algorithm>
+#include <numeric>
+
+#include "../cnnl_helper.hpp"
+
+namespace impl {
+namespace camb {
+
+extern "C" DIOPI_API diopiError_t diopiRandperm(diopiContextHandle_t ctx, diopiTensorHandle_t out, int64_t n, int64_t idx) {
+    auto out_tensor = makeTensor(out);
+    long int arr[n];
+    std::iota(arr, arr + n, 0);
+    std::random_shuffle(arr, arr + n);
+    auto ret = cnrtMemcpy(out_tensor.data(), arr, sizeof(long int) * n, cnrtMemcpyHostToDev);
+    if (ret != cnrtSuccess) {
+        set_last_error_string("%s%d", "cnrt memcpy error, ret = ", ret);
+        return diopiErrorOccurred;
+    }
+    return diopiSuccess;
+}
+
+}  // namespace camb
+}  // namespace impl


### PR DESCRIPTION
产生0~n-1，n个数随机排列，每个数字只出现一次
Example:
>>> torch.randperm(4)
tensor([2, 1, 0, 3])

>>> torch.randperm(10)
tensor([[2, 3, 6, 7, 8, 9, 1, 5, 0, 4]])

cnnl不适合此操作，也没有接口，改由cpu实现，将数据拷到mlu