### PR TITLE
add extern "C"

### DIFF
--- a/camb/functions/error.cpp
+++ b/camb/functions/error.cpp
@@ -1,4 +1,5 @@
 #include "../error.hpp"
+
 #include <diopi/functions.h>
 
 namespace impl {
@@ -16,7 +17,7 @@ const char* camb_get_last_error_string() {
     return strLastError;
 }
 
-const char* diopiGetLastErrorString() { return camb_get_last_error_string(); }
+extern "C" DIOPI_RT_API const char* diopiGetLastErrorString() { return camb_get_last_error_string(); }
 
 }  // namespace camb
 

--- a/camb/functions/info.cpp
+++ b/camb/functions/info.cpp
@@ -12,8 +12,8 @@ namespace camb {
 
 static char version[512];
 
-const char* diopiGetVendorName() { return "CambDevice"; }
-const char* diopiGetImplVersion() {
+extern "C" DIOPI_RT_API const char* diopiGetVendorName() { return "CambDevice"; }
+extern "C" DIOPI_RT_API const char* diopiGetImplVersion() {
     if (strlen(version) == 0) {
         sprintf(version, "Cnrt Version: %d; CNNL Version: %d; DIOPI Version: %d", CNRT_VERSION, CNNL_VERSION, DIOPI_VERSION);
     }


### PR DESCRIPTION
fix bug about diopiGetVendorName, diopiGetImplVersion and diopiGetLastErrorString, which has no extern "c"