### PR TITLE
feature: crossentropy

### DIFF
--- a/camb/functions/loss.cpp
+++ b/camb/functions/loss.cpp
@@ -287,7 +287,7 @@ diopiError_t diopiCrossEntropyLossBackward(diopiContextHandle_t ctx,
     diopiNLLLossBackward(ctx, grad_input, grad_output, input, target, weight, reduction, ignore_index);
     diopiLogSoftmaxBackward(ctx, grad_input, grad_output, input, 1, input_tr.dtype());
     return diopiSuccess;
-                                           }
+}
 
 }  // extern "C"
 


### PR DESCRIPTION
crossentropy： logsoftmax(bug) + nll loss

value error currently, but we can run it now