### PR TITLE
Ywt/fix cross entropy and tensor handle

### DIFF
--- a/camb/diopi_helper.hpp
+++ b/camb/diopi_helper.hpp
@@ -189,7 +189,11 @@ public:
         return p;
     }
 
-    diopiTensorHandle_t handle() {
+    diopiTensorHandle_t tensor_handle() {
+        return tensor_;
+    }
+
+    diopiConstTensorHandle_t tensor_handle() const{
         return tensor_;
     }
 


### PR DESCRIPTION
值得指出的是，加了一个tensor handle方法，获取tensor_变量

如果不这么写，那就需要在外层声明handle，然后一样使用
    diopiTensorHandle_t log_out;
    diopiSize_t output_size_diopi(input_tr.shape().data(), input_tr.shape().size());
    diopiRequireTensor(ctx, &log_out, &output_size_diopi, nullptr, input_tr.dtype(), input_tr.device());
    diopiLogSoftmax(ctx, log_out, input, 1, input_tr.dtype());

获取后就可以变成
    auto log_tr = requiresTensor(ctx, input_tr.shape(), input_tr.dtype());
    diopiLogSoftmax(ctx, log_tr.handle(), input, 1, input_tr.dtype());