### PR TITLE
fix sgd

### DIFF
--- a/camb/functions/sgd.cpp
+++ b/camb/functions/sgd.cpp
@@ -30,7 +30,7 @@ extern "C" DIOPI_API diopiError_t diopiSgd(diopiContextHandle_t ctx, diopiTensor
         if (workspace_size != 0) {
             workspace = requiresBuffer(ctx, workspace_size).data();
         }
-        
+
         DIOPI_CALLCNNL(cnnlBiasAdd(handle, &scale_b, b_desc.get(), b.data(), workspace, workspace_size, &scale_a, a_desc.get(), a.data()));
         return diopiSuccess;
     };


### PR DESCRIPTION
sgd desc的修复

当前的逻辑
1. 创建desc: CnnlTensorDesc dw_desc;
2. 执行add_mul_func ，内部会创建其他desc
3. cnnlGradientDescent(dw_desc)

某些情况下，在add_mul_func函数内部，执行CnnlTensorDesc a_desc, b_desc，dw_desc会被析构，无论add_mul_func是普通函数，还是lambda函数，都会触发。

修改方案，将dw_desc的创建，放在cnnl函数前
1. 执行add_mul_func ，内部会创建其他desc
2. 创建desc: CnnlTensorDesc dw_desc;
3. cnnlGradientDescent(dw_desc)

