### PR TITLE
fix: unintialized handle_t cause segmentfault

### DIFF
--- a/camb/diopi_helper.hpp
+++ b/camb/diopi_helper.hpp
@@ -142,7 +142,7 @@ public:
         }
         diopiSize_t stride_diopi(strides.data(), static_cast<int64_t>(strides.size()));
         diopiSize_t shape_diopi(this->shape().data(), this->shape().size());
-        diopiTensorHandle_t tensor;
+        diopiTensorHandle_t tensor = nullptr;
         diopiRequireTensor(ctx, &tensor, &shape_diopi, &stride_diopi, this->dtype(), this->device());
         return DiopiTensor(tensor);
     }
@@ -190,13 +190,9 @@ public:
         return p;
     }
 
-    diopiTensorHandle_t tensor_handle() {
-        return tensor_;
-    }
+    diopiTensorHandle_t tensor_handle() { return tensor_; }
 
-    diopiConstTensorHandle_t tensor_handle() const{
-        return tensor_;
-    }
+    diopiConstTensorHandle_t tensor_handle() const { return tensor_; }
 
 protected:
     diopiTensorHandle_t tensor_ = 0;
@@ -205,7 +201,7 @@ protected:
 };
 
 inline auto makeTensor(diopiContextHandle_t ctx, const diopiScalar_t* pScalar) -> DiopiTensor {
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     std::vector<int64_t> shape{1};
     diopiSize_t size(shape.data(), 1);
     diopiRequireTensor(ctx, &tensor, &size, nullptr, pScalar->stype, diopi_device);
@@ -213,7 +209,7 @@ inline auto makeTensor(diopiContextHandle_t ctx, const diopiScalar_t* pScalar) -
 }
 
 inline DiopiTensor ones(diopiContextHandle_t ctx, std::vector<int64_t> size, diopiDtype_t dtype) {
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     diopiSize_t size_(size.data(), size.size());
     diopiRequireTensor(ctx, &tensor, &size_, nullptr, dtype, diopi_device);
     diopiScalar_t scalar = {dtype, 1.0};
@@ -223,7 +219,7 @@ inline DiopiTensor ones(diopiContextHandle_t ctx, std::vector<int64_t> size, dio
 }
 
 inline DiopiTensor requiresTensor(diopiContextHandle_t ctx, const diopiSize_t& size, diopiDtype_t dtype) {
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     diopiRequireTensor(ctx, &tensor, &size, nullptr, dtype, diopi_device);
     return DiopiTensor(tensor);
 }
@@ -231,20 +227,20 @@ inline DiopiTensor requiresTensor(diopiContextHandle_t ctx, const diopiSize_t& s
 inline DiopiTensor requiresTensor(diopiContextHandle_t ctx, const std::vector<int64_t>& size, const std::vector<int64_t>& stride, diopiDtype_t dtype) {
     diopiSize_t size_(size.data(), size.size());
     diopiSize_t stride_(stride.data(), stride.size());
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     diopiRequireTensor(ctx, &tensor, &size_, &stride_, dtype, diopi_device);
     return DiopiTensor(tensor);
 }
 
 inline DiopiTensor requiresTensor(diopiContextHandle_t ctx, const std::vector<int64_t>& size, diopiDtype_t dtype) {
     diopiSize_t size_(size.data(), size.size());
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     diopiRequireTensor(ctx, &tensor, &size_, nullptr, dtype, diopi_device);
     return DiopiTensor(tensor);
 }
 
 inline DiopiTensor requiresBuffer(diopiContextHandle_t ctx, int64_t num_bytes) {
-    diopiTensorHandle_t tensor;
+    diopiTensorHandle_t tensor = nullptr;
     diopiRequireBuffer(ctx, &tensor, num_bytes, diopi_device);
     return DiopiTensor(tensor);
 }

--- a/camb/functions/conv_2d.cpp
+++ b/camb/functions/conv_2d.cpp
@@ -22,9 +22,9 @@ extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx,
     auto output_tensor = DiopiTensor(out);
     auto weight_tensor = DiopiTensor(weight);
 
-    diopiTensorHandle_t input_t;
-    diopiTensorHandle_t weight_t;
-    diopiTensorHandle_t output_t;
+    diopiTensorHandle_t input_t = nullptr;
+    diopiTensorHandle_t weight_t = nullptr;
+    diopiTensorHandle_t output_t = nullptr;
 
     auto permute_to_nhwc = [&](auto src, auto &dst) {
         std::vector<int64_t> axis{0, 2, 3, 1};
@@ -124,11 +124,11 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
     auto grad_input_tensor = DiopiTensor(grad_input);
     auto grad_weight_tensor = DiopiTensor(grad_weight);
 
-    diopiTensorHandle_t input_t;
-    diopiTensorHandle_t weight_t;
-    diopiTensorHandle_t grad_output_t;
-    diopiTensorHandle_t grad_input_t;
-    diopiTensorHandle_t grad_weight_t;
+    diopiTensorHandle_t input_t = nullptr;
+    diopiTensorHandle_t weight_t = nullptr;
+    diopiTensorHandle_t grad_output_t = nullptr;
+    diopiTensorHandle_t grad_input_t = nullptr;
+    diopiTensorHandle_t grad_weight_t = nullptr;
 
     auto permute_to_nhwc = [&](auto src, auto &dst) {
         std::vector<int64_t> axis{0, 2, 3, 1};

--- a/camb/functions/max_pool2d.cpp
+++ b/camb/functions/max_pool2d.cpp
@@ -170,7 +170,7 @@ DIOPI_API diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx,
 
     const void* alpha = nullptr;
     const void* beta = nullptr;
-    diopiTensorHandle_t indices32_tmp;
+    diopiTensorHandle_t indices32_tmp = nullptr;
     DIOPI_CALL(diopiRequireTensor(ctx, &indices32_tmp, &indices_shape, nullptr, diopi_dtype_int32, diopi_device));
     auto indices32_tmp_tensor = DiopiTensor(indices32_tmp);
     CnnlTensorDesc indices32_tmp_desc(indices32_tmp_tensor, CNNL_LAYOUT_NCHW);
@@ -194,7 +194,7 @@ DIOPI_API diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx,
         DIOPI_CALLCNNL(cnnlPoolingForwardWithIndex(
             handle, pool_desc, alpha, input_desc.get(), input_ptr, beta, out_desc.get(), out_ptr, indices_desc.get(), indices_ptr, workspace, workspace_size));
     } else if ((indices_dtype == CNNL_DTYPE_INT16) && (indices_dtype_ori == CNNL_DTYPE_INT32)) {
-        diopiTensorHandle_t indices16_tmp;
+        diopiTensorHandle_t indices16_tmp = nullptr;
         DIOPI_CALL(diopiRequireTensor(ctx, &indices16_tmp, &indices_shape, nullptr, diopi_dtype_int16, diopi_device));
         auto indices16_tmp_tensor = DiopiTensor(indices16_tmp);
         CnnlTensorDesc indices16_tmp_desc(indices16_tmp_tensor, CNNL_LAYOUT_NCHW);
@@ -213,7 +213,7 @@ DIOPI_API diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx,
                                                    workspace_size));
         DIOPI_CHECKCNNL(cnnlCastDataType(handle, indices16_tmp_desc.get(), indices16_tmp_ptr, CNNL_CAST_INT16_TO_INT32, indices_desc.get(), indices_ptr));
     } else {
-        diopiTensorHandle_t indices16_tmp;
+        diopiTensorHandle_t indices16_tmp = nullptr;
         DIOPI_CALL(diopiRequireTensor(ctx, &indices16_tmp, &indices_shape, nullptr, diopi_dtype_int16, diopi_device));
         auto indices16_tmp_tensor = DiopiTensor(indices16_tmp);
         CnnlTensorDesc indices16_tmp_desc(indices16_tmp_tensor, CNNL_LAYOUT_NCHW);
@@ -265,10 +265,10 @@ DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx,
         indices_dtype = CNNL_DTYPE_INT16;
     }
 
-    diopiTensorHandle_t input_t;
-    diopiTensorHandle_t grad_input_t;
-    diopiTensorHandle_t grad_output_t;
-    diopiTensorHandle_t indices_t;
+    diopiTensorHandle_t input_t = nullptr;
+    diopiTensorHandle_t grad_input_t = nullptr;
+    diopiTensorHandle_t grad_output_t = nullptr;
+    diopiTensorHandle_t indices_t = nullptr;
 
     auto permute_to_nhwc = [&](auto src, auto& dst) {
         std::vector<int64_t> axis{0, 2, 3, 1};
@@ -344,13 +344,13 @@ DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx,
     DIOPI_CALL(diopiGetTensorShape(indices_t, &indices_t_shape));
     std::vector<int> indices_shape_{indices_t_shape.data, indices_t_shape.data + indices_t_shape.len};
 
-    diopiTensorHandle_t indices32_cast;
+    diopiTensorHandle_t indices32_cast = nullptr;
     DIOPI_CALL(diopiRequireTensor(ctx, &indices32_cast, &indices_t_shape, nullptr, diopi_dtype_int32, diopi_device));
     auto indices32_cast_tensor = DiopiTensor(indices32_cast);
     CnnlTensorDesc indices32_cast_desc;
     DIOPI_CALL(indices32_cast_desc.set(indices32_cast_tensor, CNNL_LAYOUT_NHWC, indices_shape_));
 
-    diopiTensorHandle_t indices16_cast;
+    diopiTensorHandle_t indices16_cast = nullptr;
     DIOPI_CALL(diopiRequireTensor(ctx, &indices16_cast, &indices_t_shape, nullptr, diopi_dtype_int16, diopi_device));
     auto indices16_cast_tensor = DiopiTensor(indices16_cast);
     CnnlTensorDesc indices16_cast_desc;


### PR DESCRIPTION
将handle_t初始化为nullptr，防止可能的未初始化导致segment fault