### PR TITLE
fix: string decode error

### DIFF
--- a/camb/error.hpp
+++ b/camb/error.hpp
@@ -30,7 +30,7 @@ inline void set_last_error_string(const char* szFmt, Types&&... args) {
 
 const char* camb_get_last_error_string();
 
-const std::string getDiopiErrorStr(diopiError_t err);
+const char* getDiopiErrorStr(diopiError_t err);
 
 }  // namespace camb
 

--- a/camb/functions/error.cpp
+++ b/camb/functions/error.cpp
@@ -18,14 +18,14 @@ std::mutex mtxLastError;
 const char* camb_get_last_error_string() {
     // consider cnrt version cnrtGetLastErr or cnrtGetLaislhhstError
     ::cnrtRet_t err = ::cnrtGetLastError();
-std::lock_guard<std::mutex> lock(mtxLastError);
+    std::lock_guard<std::mutex> lock(mtxLastError);
     sprintf(strLastError, "camb error: %s, more infos: %s", ::cnrtGetErrorStr(err), strLastErrorOther);
     return strLastError;
 }
 
 extern "C" DIOPI_RT_API const char* diopiGetLastErrorString() { return camb_get_last_error_string(); }
 
-const std::string getDiopiErrorStr(diopiError_t err) {
+const char* getDiopiErrorStr(diopiError_t err) {
     switch (err) {
         case diopiErrorOccurred:
             return "diopiErrorOccurred";
@@ -53,6 +53,8 @@ const std::string getDiopiErrorStr(diopiError_t err) {
             return "diopi5DNotSupported";
         case diopiDtypeNotSupported:
             return "diopiDtypeNotSupported";
+        default:
+            return "diopiUnexpectedError";
     }
 }
 


### PR DESCRIPTION
Fix "ConformanceTest - ERROR - 'utf-8' codec can't decode byte 0xa1 in position 36: invalid start byte"
The reason is passing std::string to `sprintf`