### PR TITLE
conv2d support fp64

### DIFF
--- a/camb/functions/conv_2d.cpp
+++ b/camb/functions/conv_2d.cpp
@@ -77,7 +77,7 @@ extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx, diopiTensor
 
     CnnlResourceGuard<cnnlConvolutionDescriptor_t, cnnlCreateConvolutionDescriptor, cnnlDestroyConvolutionDescriptor> conv_desc;
 
-    int padding_[4] = {padding_vec[0], padding_vec[1], padding_vec[0], padding_vec[1]};
+    int padding_[4] = {padding_vec[0], padding_vec[0], padding_vec[1], padding_vec[1]};
     int stride_[2] = {stride_vec[0], stride_vec[1]};
     int dilation_[2] = {dilation_vec[0], dilation_vec[1]};
 

--- a/camb/functions/conv_2d.cpp
+++ b/camb/functions/conv_2d.cpp
@@ -9,58 +9,66 @@
 #include <numeric>
 #include <vector>
 
-#include "../cnnl_helper.hpp"
+#include "../common/common.hpp"
 
 namespace impl {
 namespace camb {
-extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx,
-                                           diopiTensorHandle_t out,
-                                           diopiConstTensorHandle_t input,
-                                           diopiConstTensorHandle_t weight,
-                                           diopiConstTensorHandle_t bias,
-                                           diopiSize_t stride,
-                                           diopiSize_t padding,
-                                           diopiSize_t dilation,
-                                           int64_t groups) {
+
+namespace {
+diopiError_t diopiTensorPermote(diopiContextHandle_t ctx, DiopiTensor &dst_tensor, DiopiTensor src_tensor, std::vector<int64_t> perm_axis) {
+    if (!dst_tensor.defined()) {
+        std::vector<int64_t> src_shape_t_64(src_tensor.shape().size());
+        for (int i = 0; i < src_tensor.shape().size(); ++i) {
+            src_shape_t_64[i] = src_tensor.shape()[perm_axis[i]];
+        }
+        diopiSize_t src_t_shape(src_shape_t_64.data(), src_shape_t_64.size());
+        auto dst_handle = dst_tensor.tensorHandle();
+        DIOPI_CALL(diopiRequireTensor(ctx, &dst_handle, &src_t_shape, nullptr, src_tensor.dtype(), diopi_device));
+        dst_tensor = DiopiTensor(dst_handle);
+    }
+    diopiSize_t axis_size(perm_axis.data(), 4);
+    DIOPI_CALL(diopiPermute(ctx, dst_tensor.tensorHandle(), src_tensor.tensorHandle(), axis_size));
+    return diopiSuccess;
+}
+
+}  // namespace
+
+extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
+                                           diopiConstTensorHandle_t bias, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, int64_t groups) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor input_tensor(input);
-    DiopiTensor output_tensor(out);
     DiopiTensor weight_tensor(weight);
+    DiopiTensor output_tensor(out);
 
-    diopiTensorHandle_t input_t = nullptr;
-    diopiTensorHandle_t weight_t = nullptr;
-    diopiTensorHandle_t output_t = nullptr;
+    DiopiTensor input_tensor_casted = input_tensor;
+    DiopiTensor weight_tensor_casted = weight_tensor;
+    DiopiTensor output_tensor_casted = output_tensor;
 
-    auto permute_to_nhwc = [&](auto src, auto &dst) {
-        std::vector<int64_t> axis{0, 2, 3, 1};
-        DiopiTensor src_tensor(src);
-        std::vector<int64_t> src_shape_t_64(src_tensor.shape().size());
-        for (int i = 0; i < src_tensor.shape().size(); ++i) {
-            src_shape_t_64[i] = src_tensor.shape()[axis[i]];
-        }
-        diopiSize_t src_t_shape(src_shape_t_64.data(), src_shape_t_64.size());
-        DIOPI_CALL(diopiRequireTensor(ctx, &dst, &src_t_shape, nullptr, src_tensor.dtype(), diopi_device));
-        diopiSize_t nchw2nhwc(axis.data(), 4);
-        DIOPI_CALL(diopiPermute(ctx, dst, src, nchw2nhwc));
-        return diopiSuccess;
-    };
+    std::vector<DiopiTensor *> tensors{&input_tensor_casted, &weight_tensor_casted, &output_tensor_casted};
+    DIOPI_CALL(autoCastTensorType(ctx, tensors, {diopi_dtype_float16, diopi_dtype_float32}));
 
-    DIOPI_CALL(permute_to_nhwc(input, input_t));
-    DIOPI_CALL(permute_to_nhwc(weight, weight_t));
-    DIOPI_CALL(permute_to_nhwc(out, output_t));
+    DiopiTensor input_tensor_t, weight_tensor_t, output_tensor_t;
 
-    CnnlTensorDesc input_desc, output_desc, weight_desc;
-    DIOPI_CALL(input_desc.set(input_tensor, CNNL_LAYOUT_NHWC));
-    DIOPI_CALL(output_desc.set(output_tensor, CNNL_LAYOUT_NHWC));
-    DIOPI_CALL(weight_desc.set(weight_tensor, CNNL_LAYOUT_NHWC));
+    DIOPI_CALL(diopiTensorPermote(ctx, input_tensor_t, input_tensor_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, output_tensor_t, output_tensor_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, weight_tensor_t, weight_tensor_casted, {0, 2, 3, 1}));
 
-    const void *bias_ptr = nullptr;
-    CnnlTensorDesc bias_desc;
+    std::vector<int32_t> input_t_shape{input_tensor_t.shape().begin(), input_tensor_t.shape().end()};
+    std::vector<int32_t> weight_t_shape{weight_tensor_t.shape().begin(), weight_tensor_t.shape().end()};
+    std::vector<int32_t> output_t_shape{output_tensor_t.shape().begin(), output_tensor_t.shape().end()};
+
+    CnnlTensorDesc input_desc(input_tensor_t, CNNL_LAYOUT_NHWC, input_t_shape);
+    CnnlTensorDesc weight_desc(weight_tensor_t, CNNL_LAYOUT_NHWC, weight_t_shape);
+    CnnlTensorDesc output_desc(output_tensor_t, CNNL_LAYOUT_NHWC, output_t_shape);
+
     DiopiTensor bias_tensor(bias);
+    DiopiTensor bias_tensor_casted = bias_tensor;
+    CnnlTensorDesc bias_desc;
     if (nullptr != bias) {
-        DIOPI_CALL(bias_desc.set(bias_tensor, CNNL_LAYOUT_ARRAY));
-        bias_ptr = bias_tensor.data();
+        std::vector<DiopiTensor *> tensors{&bias_tensor_casted};
+        DIOPI_CALL(autoCastTensorType(ctx, tensors, {diopi_dtype_float16, diopi_dtype_float32}));
+        DIOPI_CALL(bias_desc.set(bias_tensor_casted, CNNL_LAYOUT_ARRAY));
     }
 
     std::vector<int> stride_vec{stride.data, stride.data + stride.len};
@@ -73,9 +81,9 @@ extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx,
     int stride_[2] = {stride_vec[0], stride_vec[1]};
     int dilation_[2] = {dilation_vec[0], dilation_vec[1]};
 
-    cnnlDataType_t input_type;
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&input_type, input_tensor.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(conv_desc.get(), 4, padding_, stride_, dilation_, groups, input_type));
+    cnnlDataType_t compute_type;
+    DIOPI_CALL(CnnlDataType::convertToCnnlType(&compute_type, input_tensor_t.dtype()));
+    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(conv_desc.get(), 4, padding_, stride_, dilation_, groups, compute_type));
 
     size_t workspace_size;
     DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(
@@ -91,37 +99,26 @@ extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx,
                                           CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
                                           NULL,
                                           input_desc.get(),
-                                          DiopiTensor(input_t).data(),
+                                          input_tensor_t.data(),
                                           weight_desc.get(),
-                                          DiopiTensor(weight_t).data(),
-                                          bias_tensor.defined()?bias_desc.get() : nullptr,
-                                          bias_tensor.defined()?bias_tensor.data() : nullptr,
+                                          weight_tensor_t.data(),
+                                          bias_tensor.defined() ? bias_desc.get() : nullptr,
+                                          bias_tensor.defined() ? bias_tensor_casted.data() : nullptr,
                                           workspace,
                                           workspace_size,
                                           NULL,
                                           output_desc.get(),
-                                          DiopiTensor(output_t).data()));
+                                          output_tensor_t.data()));
 
-    std::vector<int64_t> perm_nhwc2nchw{0, 3, 1, 2};
-    diopiSize_t nhwc2nchw(perm_nhwc2nchw.data(), 4);
-    DIOPI_CALL(diopiPermute(ctx, out, output_t, nhwc2nchw));
+    DIOPI_CALL(diopiTensorPermote(ctx, output_tensor_casted, output_tensor_t, {0, 3, 1, 2}));
+    DIOPI_CALL(dataTypeCast(ctx, output_tensor, output_tensor_casted));
     return diopiSuccess;
 }
 
-extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
-                                                   diopiTensorHandle_t grad_input,
-                                                   diopiTensorHandle_t grad_weight,
-                                                   diopiTensorHandle_t grad3,
-                                                   diopiConstTensorHandle_t grad_output,
-                                                   diopiConstTensorHandle_t input,
-                                                   diopiConstTensorHandle_t weight,
-                                                   diopiSize_t *bias_sizes,
-                                                   diopiSize_t stride,
-                                                   diopiSize_t padding,
-                                                   diopiSize_t dilation,
-                                                   bool transposed,
-                                                   diopiSize_t output_padding,
-                                                   int64_t groups) {
+extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
+                                                   diopiTensorHandle_t grad3, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                   diopiConstTensorHandle_t weight, diopiSize_t *bias_sizes, diopiSize_t stride, diopiSize_t padding,
+                                                   diopiSize_t dilation, bool transposed, diopiSize_t output_padding, int64_t groups) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor input_tensor(input);
@@ -130,43 +127,34 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
     DiopiTensor grad_input_tensor(grad_input);
     DiopiTensor grad_weight_tensor(grad_weight);
 
-    diopiTensorHandle_t input_t = nullptr;
-    diopiTensorHandle_t weight_t = nullptr;
-    diopiTensorHandle_t grad_output_t = nullptr;
-    diopiTensorHandle_t grad_input_t = nullptr;
-    diopiTensorHandle_t grad_weight_t = nullptr;
+    DiopiTensor input_casted = input_tensor;
+    DiopiTensor weight_casted = weight_tensor;
+    DiopiTensor grad_output_casted = grad_output_tensor;
+    DiopiTensor grad_input_casted = grad_input_tensor;
+    DiopiTensor grad_weight_casted = grad_weight_tensor;
 
-    auto permute_to_nhwc = [&](auto src, auto &dst) {
-        std::vector<int64_t> axis{0, 2, 3, 1};
-        DiopiTensor src_tensor(src);
-        std::vector<int64_t> src_shape_t_64(src_tensor.shape().size());
-        for (int i = 0; i < src_tensor.shape().size(); ++i) {
-            src_shape_t_64[i] = src_tensor.shape()[axis[i]];
-        }
-        diopiSize_t src_t_shape(src_shape_t_64.data(), src_shape_t_64.size());
-        DIOPI_CALL(diopiRequireTensor(ctx, &dst, &src_t_shape, nullptr, src_tensor.dtype(), diopi_device));
-        diopiSize_t nchw2nhwc(axis.data(), 4);
-        DIOPI_CALL(diopiPermute(ctx, dst, src, nchw2nhwc));
-        return diopiSuccess;
-    };
+    std::vector<DiopiTensor *> tensors{&input_casted, &weight_casted, &grad_output_casted, &grad_input_casted, &grad_weight_casted};
+    DIOPI_CALL(autoCastTensorType(ctx, tensors, {diopi_dtype_float16, diopi_dtype_float32}));
 
-    DIOPI_CALL(permute_to_nhwc(input, input_t));
-    DIOPI_CALL(permute_to_nhwc(weight, weight_t));
-    DIOPI_CALL(permute_to_nhwc(grad_output, grad_output_t));
-    DIOPI_CALL(permute_to_nhwc(grad_input, grad_input_t));
-    DIOPI_CALL(permute_to_nhwc(grad_weight, grad_weight_t));
+    DiopiTensor input_t, weight_t, grad_output_t, grad_input_t, grad_weight_t;
 
-    DiopiTensor input_tensor_t(input_t);
-    DiopiTensor weight_tensor_t(weight_t);
-    DiopiTensor grad_output_tensor_t(grad_output_t);
-    DiopiTensor grad_input_tensor_t(grad_input_t);
-    DiopiTensor grad_weight_tensor_t(grad_weight_t);
+    DIOPI_CALL(diopiTensorPermote(ctx, input_t, input_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, weight_t, weight_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, grad_output_t, grad_output_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, grad_input_t, grad_input_casted, {0, 2, 3, 1}));
+    DIOPI_CALL(diopiTensorPermote(ctx, grad_weight_t, grad_weight_casted, {0, 2, 3, 1}));
 
-    CnnlTensorDesc input_desc(input_tensor, CNNL_LAYOUT_NHWC);
-    CnnlTensorDesc weight_desc(weight_tensor, CNNL_LAYOUT_NHWC);
-    CnnlTensorDesc output_grad_desc(grad_output_tensor, CNNL_LAYOUT_NHWC);
-    CnnlTensorDesc input_grad_desc(grad_input_tensor, CNNL_LAYOUT_NHWC);
-    CnnlTensorDesc weight_grad_desc(grad_weight_tensor, CNNL_LAYOUT_NHWC);
+    std::vector<int32_t> input_t_shape{input_t.shape().begin(), input_t.shape().end()};
+    std::vector<int32_t> weight_t_shape{weight_t.shape().begin(), weight_t.shape().end()};
+    std::vector<int32_t> grad_output_t_shape{grad_output_t.shape().begin(), grad_output_t.shape().end()};
+    std::vector<int32_t> grad_input_t_shape{grad_input_t.shape().begin(), grad_input_t.shape().end()};
+    std::vector<int32_t> grad_weight_shape{grad_weight_t.shape().begin(), grad_weight_t.shape().end()};
+
+    CnnlTensorDesc input_desc(input_t, CNNL_LAYOUT_NHWC, input_t_shape);
+    CnnlTensorDesc weight_desc(weight_t, CNNL_LAYOUT_NHWC, weight_t_shape);
+    CnnlTensorDesc output_grad_desc(grad_output_t, CNNL_LAYOUT_NHWC, grad_output_t_shape);
+    CnnlTensorDesc input_grad_desc(grad_input_t, CNNL_LAYOUT_NHWC, grad_input_t_shape);
+    CnnlTensorDesc weight_grad_desc(grad_weight_t, CNNL_LAYOUT_NHWC, grad_weight_shape);
 
     CnnlResourceGuard<cnnlConvolutionDescriptor_t, cnnlCreateConvolutionDescriptor, cnnlDestroyConvolutionDescriptor> conv_desc;
 
@@ -178,9 +166,9 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
     int stride_[2] = {stride_vec[0], stride_vec[1]};
     int dilation_[2] = {dilation_vec[0], dilation_vec[1]};
 
-    cnnlDataType_t input_type;
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&input_type, input_tensor_t.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(conv_desc.get(), 4, padding_, stride_, dilation_, groups, input_type));
+    cnnlDataType_t compute_type;
+    DIOPI_CALL(CnnlDataType::convertToCnnlType(&compute_type, input_t.dtype()));
+    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(conv_desc.get(), 4, padding_, stride_, dilation_, groups, compute_type));
 
     size_t workspace_size_filter = 0;
     DIOPI_CALLCNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(
@@ -194,16 +182,16 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
     DIOPI_CALLCNNL(cnnlConvolutionBackwardFilter(handle,
                                                  NULL,
                                                  input_desc.get(),
-                                                 input_tensor_t.data(),
+                                                 input_t.data(),
                                                  output_grad_desc.get(),
-                                                 grad_output_tensor_t.data(),
+                                                 grad_output_t.data(),
                                                  conv_desc.get(),
                                                  CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT,
                                                  workspace_filter,
                                                  workspace_size_filter,
                                                  NULL,
                                                  weight_grad_desc.get(),
-                                                 grad_weight_tensor_t.data()));
+                                                 grad_weight_t.data()));
 
     size_t workspace_size_input;
     DIOPI_CALLCNNL(cnnlGetConvolutionBackwardDataWorkspaceSize(handle,
@@ -222,44 +210,40 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx,
     DIOPI_CALLCNNL(cnnlConvolutionBackwardData(handle,
                                                NULL,
                                                weight_desc.get(),
-                                               weight_tensor_t.data(),
+                                               weight_t.data(),
                                                output_grad_desc.get(),
-                                               grad_output_tensor_t.data(),
+                                               grad_output_t.data(),
                                                conv_desc.get(),
                                                CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT,
                                                workspace_input,
                                                workspace_size_input,
                                                NULL,
                                                input_grad_desc.get(),
-                                               grad_input_tensor_t.data()));
+                                               grad_input_t.data()));
 
-    std::vector<int64_t> perm_nhwc2nchw{0, 3, 1, 2};
-    diopiSize_t nhwc2nchw(perm_nhwc2nchw.data(), 4);
-    DIOPI_CALL(diopiPermute(ctx, grad_input, grad_input_t, nhwc2nchw));
-    DIOPI_CALL(diopiPermute(ctx, grad_weight, grad_weight_t, nhwc2nchw));
+    DIOPI_CALL(diopiTensorPermote(ctx, grad_input_casted, grad_input_t, {0, 3, 1, 2}));
+    DIOPI_CALL(diopiTensorPermote(ctx, grad_weight_casted, grad_weight_t, {0, 3, 1, 2}));
+    DIOPI_CALL(dataTypeCast(ctx, grad_input_tensor, grad_input_casted));
+    DIOPI_CALL(dataTypeCast(ctx, grad_weight_tensor, grad_weight_casted));
 
     if (grad3 != nullptr) {
         DiopiTensor bias_grad_tensor(grad3);
-        CnnlTensorDesc bias_grad_desc;
-        DIOPI_CALL(bias_grad_desc.set(bias_grad_tensor, CNNL_LAYOUT_ARRAY));
+        DiopiTensor grad_bias_casted = bias_grad_tensor;
+        std::vector<DiopiTensor *> tensors{&grad_bias_casted};
+        DIOPI_CALL(autoCastTensorType(ctx, tensors, {diopi_dtype_float16, diopi_dtype_float32}));
+        CnnlTensorDesc bias_grad_desc(grad_bias_casted, CNNL_LAYOUT_ARRAY);
         std::vector<int64_t> bias_shape{bias_grad_tensor.shape().begin(), bias_grad_tensor.shape().end()};
         bias_sizes->data = bias_shape.data();
         bias_sizes->len = bias_shape.size();
         size_t workspace_size_bias;
         DIOPI_CALLCNNL(cnnlGetBiasAddBackwardWorkspaceSize(handle, output_grad_desc.get(), bias_grad_desc.get(), 3, &workspace_size_bias))
-
         void *workspace_bias = nullptr;
         if (0 != workspace_size_bias) {
             workspace_bias = requiresBuffer(ctx, workspace_size_bias).data();
         }
-        DIOPI_CALLCNNL(cnnlBiasAddBackward_v2(handle,
-                                              output_grad_desc.get(),
-                                              grad_output_tensor_t.data(),
-                                              3,
-                                              bias_grad_desc.get(),
-                                              bias_grad_tensor.data(),
-                                              workspace_bias,
-                                              workspace_size_bias));
+        DIOPI_CALLCNNL(cnnlBiasAddBackward_v2(
+            handle, output_grad_desc.get(), grad_output_t.data(), 3, bias_grad_desc.get(), grad_bias_casted.data(), workspace_bias, workspace_size_bias));
+        DIOPI_CALL(dataTypeCast(ctx, bias_grad_tensor, grad_bias_casted))
     }
 
     return diopiSuccess;


### PR DESCRIPTION
修复conv2d padding问题，测例中缺少类似padding(1, 0)，padding是元组，且不对称的测例，所以之前没有测出来